### PR TITLE
fix: accomodate invert-hist second Axes obj

### DIFF
--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -314,7 +314,7 @@ class CellResponse(object):
             cell_response=self, trial_idx=trial_idx, ax=ax, show=show)
 
     def plot_spikes_hist(self, trial_idx=None, ax=None, spike_types=None,
-                         invert_spike_types=None, color=None, show=True,
+                         color=None, invert_spike_types=None, show=True,
                          **kwargs_hist):
         """Plot the histogram of spiking activity across trials.
 

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -526,6 +526,11 @@ def _clear_axis(b, widgets, data, fig_idx, fig, ax, widgets_plot_type,
                 existing_plots, add_plot_button):
     ax.clear()
 
+    # Remove "plot_spikes_hist"'s inverted second axes object, if exists
+    for axis in fig.axes:
+        if axis._label == "Inverted second axis":
+            axis.remove()
+
     # remove attached colorbar if exists
     if hasattr(fig, f'_cbar-ax-{id(ax)}'):
         getattr(fig, f'_cbar-ax-{id(ax)}').ax.remove()

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -651,63 +651,47 @@ def test_gui_figure_overlay(setup_gui):
     plt.close('all')
 
 
-def test_gui_adaptive_spectrogram(setup_gui):
-    """Test the adaptive spectrogram functionality of the HNNGUI."""
-    gui = setup_gui
-
-    gui.run_button.click()
-    figid = 1
-    figname = f'Figure {figid}'
-    axname = 'ax1'
-    gui._simulate_viz_action("edit_figure", figname, axname, 'default',
-                             'spectrogram', {}, 'clear')
-    gui._simulate_viz_action("edit_figure", figname, axname, 'default',
-                             'spectrogram', {}, 'plot')
-    # make sure the colorbar is correctly added
-    assert any(['_cbar-ax-' in attr
-                for attr in dir(gui.viz_manager.figs[figid])]) is True
-    assert len(gui.viz_manager.figs[1].axes) == 3
-    # make sure the colorbar is safely removed
-    gui._simulate_viz_action("edit_figure", figname, axname, 'default',
-                             'spectrogram', {}, 'clear')
-    assert any(['_cbar-ax-' in attr
-                for attr in dir(gui.viz_manager.figs[figid])]) is False
-    assert len(gui.viz_manager.figs[1].axes) == 2
-    plt.close('all')
-
-
 def test_gui_visualization(setup_gui):
     """Tests updating a figure creates plots with data."""
 
     gui = setup_gui
     gui.run_button.click()
 
-    figid = 1
+    gui._simulate_viz_action("switch_fig_template", "[Blank] single figure")
+    gui._simulate_viz_action("add_fig")
+    figid = 2
     figname = f'Figure {figid}'
-    axname = 'ax1'
-    # Spectrogram has a separate test and does not need to be tested here
-    gui_plots_no_spectrogram = [s for s in _plot_types if s != 'spectrogram']
+    axname = 'ax0'
 
-    plot_types = ['current dipole',
-                  'layer2 dipole',
-                  'layer5 dipole',
-                  'input histogram',
-                  'spikes',
-                  'PSD',
-                  'network']
-    # Make sure all plot types are tested.
-    assert len(plot_types) == len(gui_plots_no_spectrogram)
-    assert all([name in gui_plots_no_spectrogram for name in plot_types])
-
-    for viz_type in plot_types:
+    for viz_type in _plot_types:
         gui._simulate_viz_action("edit_figure", figname,
                                  axname, 'default', viz_type, {}, 'clear')
         gui._simulate_viz_action("edit_figure", figname,
                                  axname, 'default', viz_type, {}, 'plot')
         # Check if data is plotted on the axes
-        assert len(gui.viz_manager.figs[figid].axes) == 2
-        # Check default figs have data on their axis
-        assert gui.viz_manager.figs[figid].axes[1].has_data()
+        assert gui.viz_manager.figs[figid].axes[0].has_data()
+
+        if viz_type == "input histogram":
+            # Check if the correct number of axes are present
+            # "input histogram" is a special case due to "plot_spikes_hist" using 2 axes
+            assert len(gui.viz_manager.figs[figid].axes) == 2
+        elif viz_type == "spectrogram":
+            # make sure the colorbar is correctly added
+            assert any(['_cbar-ax-' in attr
+                        for attr in dir(gui.viz_manager.figs[figid])]) is True
+            assert len(gui.viz_manager.figs[figid].axes) == 2
+
+            # make sure the colorbar is safely removed
+            gui._simulate_viz_action("edit_figure", figname, axname, 'default',
+                                     'spectrogram', {}, 'clear')
+            assert any(['_cbar-ax-' in attr
+                        for attr in dir(gui.viz_manager.figs[figid])]) is False
+            assert len(gui.viz_manager.figs[figid].axes) == 1
+
+        else:
+            # Check if the correct number of axes are present
+            assert len(gui.viz_manager.figs[figid].axes) == 1
+
     plt.close('all')
 
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -537,6 +537,8 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
                 ax1 = ax.twinx()
             ax1.hist(plot_data, bins,
                      label=spike_label, color=hist_color, **kwargs_hist)
+            # Need to add label for easy removal later
+            ax1.set_label("Inverted second axis")
 
     # Set the y-limits based on the maximum across both axes
     if ax1 is not None:


### PR DESCRIPTION
Since the addition of inverted spike histograms requires the use of two Axes objects, we need to change a few small things:

1. Add a label to our new, second Axes object upon creation in `viz`
2. Use this label to completely remove the second Axes object when "Clear axis" button is pressed
3. Since axes of type "input histogram" are now going to have 2 Axes object, while most others will only have 1, we need to make an exception in the testing. I have done so in `tests/test_gui.py` along with a small refactor.

The test refactor consists of moving the content of `test_gui_adaptive_spectrogram` into just another case of the `test_gui_visualization` test. Additionally, all tests in that test now take place in a brand-new "Blank single figure", so that their total axes number do NOT include those of axes that are not the current `viz_type` being tested (which was the case before).