### PR TITLE
gui: more L2->L2/3 gui display, sync plot names

### DIFF
--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -21,13 +21,13 @@ _fig_placeholder = 'Run simulation to add figures here.'
 
 _plot_types = [
     'current dipole',
-    'layer2 dipole',
+    'layer2/3 dipole',
     'layer5 dipole',
     'input histogram',
     'spikes',
     'PSD',
-    'layer 2 PSD',
-    'layer 5 PSD',
+    'layer2/3 PSD',
+    'layer5 PSD',
     'spectrogram',
     'network',
 ]
@@ -95,7 +95,7 @@ data_templates = {
             "gridspec_kw": {"height_ratios": [1, 1, 1]}
         },
         "mosaic": "0\n1\n2",
-        "ax_plots": [("ax0", "layer2 dipole"), ("ax1", "layer5 dipole"),
+        "ax_plots": [("ax0", "layer2/3 dipole"), ("ax1", "layer5 dipole"),
                      ("ax2", "current dipole")]
     },
     "Drive-Spikes (2x1)": {
@@ -133,8 +133,8 @@ data_templates = {
         },
         "mosaic": "0\n1\n2",
         "ax_plots": [
-            ("ax0", "layer 2 PSD"),
-            ("ax1", "layer 5 PSD"),
+            ("ax0", "layer2/3 PSD"),
+            ("ax1", "layer5 PSD"),
             ("ax2", "PSD"),
         ]
     }
@@ -308,7 +308,7 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
                 show=False
             )
 
-    elif plot_type == 'layer 2 PSD':
+    elif plot_type == 'layer2/3 PSD':
         if len(dpls_copied) > 0:
             min_f = plot_config['min_spectral_frequency']
             max_f = plot_config['max_spectral_frequency']
@@ -324,7 +324,7 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
                 show=False
             )
 
-    elif plot_type == 'layer 5 PSD':
+    elif plot_type == 'layer5 PSD':
         if len(dpls_copied) > 0:
             min_f = plot_config['min_spectral_frequency']
             max_f = plot_config['max_spectral_frequency']
@@ -384,7 +384,7 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
                             show=False)
             else:
                 layer_namemap = {
-                    "layer2": "L2",
+                    "layer2/3": "L2",
                     "layer5": "L5",
                 }
                 plot_dipole(dpls_copied,

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1178,7 +1178,7 @@ def test_default_smoothing(setup_gui):
 
     _dipole_plot_types = [
         'current dipole',
-        'layer2 dipole',
+        'layer2/3 dipole',
         'layer5 dipole',
     ]
 


### PR DESCRIPTION
This changes the dropdown plot type names so that the user always has "layer2/3" displayed instead of "layer2". Also, I removed the space between layer and the number for the PSD labels because:

1. it's more consistent with the existing dipole plot type names, and
2. the dipole plot type names *require* the only space in the string to be between the layer names and "dipole" currently, see https://github.com/jonescompneurolab/hnn-core/blob/master/hnn_core/gui/_viz_manager.py#L350 