### PR TITLE
Ref/misc review tm currents

### DIFF
--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -822,28 +822,22 @@ class Cell:
                 - "soma" : only the soma
                 - "all"  : all sections in `section_names`
                 - None   : skip
-
         name : str
             the attribute name to hold the recordings; e.g., for name="ina",
             the recording would be accessed with "self.ina"
-
         section_names : list
             list of available section names
-
         mech : str or None
             The mechanism inside a section segment (e.g., "hh2") to use for recording
             If None, the current is recorded directly from the section
             itself (from the top-level variable)
-
         ref : str
             The name of the hoc reference variable to record from (e.g., "_ref_ina"
             for sodium)
-
         per_segment: bool
             If True, record from every segment in the section
                 - keys will follow the format: "seg_x_0.500"
             If False, record only from the midpoint (0.5)
-
         """
 
         # create an attribute on self to hold the currents
@@ -1015,7 +1009,7 @@ class Cell:
             Option to record voltages from all sections ('all'), or just
             the soma ('soma'). Default: False.
         record_isec : 'all' | 'soma' | False
-            Option to record voltages from all sections ('all'), or just
+            Option to record currents from all sections ('all'), or just
             the soma ('soma'). Default: False.
         record_ca : 'all' | 'soma' | False
             Option to record calcium concentration from all sections ('all'),

--- a/test_tm_currents.py
+++ b/test_tm_currents.py
@@ -555,7 +555,7 @@ def calculate_neuron_geometry(
     for child_section in sorted_sections:
         child_section_start = end_pts[child_section][0]
 
-        # set shift for basal_1, which shoud move in the negative direction along
+        # set shift for basal_1, which should move in the negative direction along
         # the z axis
         if child_section != "soma" and child_section_start == end_pts["soma"][0]:
             # the vertical offset for basal 2/3 should be negative
@@ -1982,7 +1982,7 @@ def postproc_soma_dipole(
 
             I_t += I_abs
 
-        # arround for different structure for isec when recontructing from components
+        # around for different structure for isec when reconstructing from components
         if from_components:
             soma_isec = net.cell_response.isec[trial][gid].get(sec_name, {})
             for syn_key in soma_isec:
@@ -2213,8 +2213,9 @@ check_rmse_and_residuals(net)
 # %% ---------------------------------------------------
 # Notes:
 # - ".glb" is a standardized format for 3D models
-# - files can be openened in free model viewers such as
+# - files can be opened in free model viewers such as
 #   https://modelviewer.dev/editor/
+
 
 def generate_blender_neuron(
     end_pts,
@@ -2225,8 +2226,7 @@ def generate_blender_neuron(
     scale_factor=0.01,
     width_scale=2.0,
 ):
-    """
-    """
+    """ """
     diameters = extract_diameters(
         end_pts.keys(),
         defaults,


### PR DESCRIPTION
This applies some trivial changes for https://github.com/jonescompneurolab/hnn-core/pull/1212 

1. Moves `hnn_core/tests/test_tm_currents.py` to `test_tm_currents.py` so that it is not included as part of `pytest` runs
2. Fix some `codespell`-error spelling mistakes in `test_tm_currents.py`
3. Apply a few trivial docstring changes that Nick suggested